### PR TITLE
音声コールバックのハングから自動復旧する

### DIFF
--- a/src/voice_input/app.py
+++ b/src/voice_input/app.py
@@ -16,7 +16,13 @@ from .device_monitor import DeviceMonitor
 from .hotkey import HOTKEY_NAMES, HotkeyListener
 from .logger import get_logger
 from .output import output_text
-from .recorder import SAMPLE_RATE, StreamingRecorder, save_audio
+from .recorder import (
+    SAMPLE_RATE,
+    StreamingRecorder,
+    UnrecoverableAudioError,
+    save_audio,
+)
+from .restart import schedule_self_restart
 from .transcriber import transcribe
 
 logger = get_logger()
@@ -28,6 +34,11 @@ MIN_RECORDING_SECONDS = 0.3
 # int16 audio ranges from -32768 to 32767
 # This threshold filters out silence and very quiet recordings
 MIN_RMS_THRESHOLD = 100
+
+# If the audio callback has not fired for this many seconds while we believe
+# we're recording, treat the stream as hung (AUHAL thread stuck) and force
+# a stop + reinitialize. Sized to be well above normal scheduling jitter.
+CALLBACK_STALL_THRESHOLD_SEC = 2.0
 
 # Recording mode names for menu display
 MODE_NAMES = {
@@ -213,6 +224,10 @@ class VoiceInputApp(rumps.App):
             if self.recorder.is_initialized:
                 self.recorder.reinitialize()
             self._event_queue.put("status:Ready (device updated)")
+        except UnrecoverableAudioError as e:
+            logger.error(f"App: Unrecoverable audio state on device switch: {e}")
+            self._notify_error("デバイス切替時に音声ストリーム復旧不能、再起動します")
+            schedule_self_restart(f"device switch reinit: {e}")
         except (RuntimeError, sd.PortAudioError) as e:
             logger.exception(f"App: Failed to reinitialize with device: {e}")
             self._event_queue.put(f"error:{e}")
@@ -235,6 +250,23 @@ class VoiceInputApp(rumps.App):
     @rumps.timer(0.05)
     def _check_events(self, _sender: object) -> None:
         """Poll for hotkey events from the queue."""
+        # Detect a silently-stalled audio callback (e.g., AUHAL thread hung
+        # without any sleep/device-change notification). If we believe we're
+        # recording but no sample has arrived for a while, abort and reinit.
+        if self._is_recording and self.recorder.is_recording:
+            idle = self.recorder.seconds_since_last_callback()
+            if idle is not None and idle > CALLBACK_STALL_THRESHOLD_SEC:
+                logger.warning(
+                    "App: Audio callback stalled for %.1fs — forcing stop + reinit",
+                    idle,
+                )
+                self._auto_stopped = True
+                self._is_recording = False
+                self._stop_recording()
+                self._event_queue.put("status:Ready (recovered from stall)")
+                self._event_queue.put("reinitialize")
+                return
+
         # Auto-stop for toggle mode if recording exceeds max duration
         if (
             self._current_mode == "toggle"
@@ -320,6 +352,10 @@ class VoiceInputApp(rumps.App):
             self.recorder.set_device(device_index)
             self.recorder.reinitialize()
             self._event_queue.put("status:Ready (retry recording)")
+        except UnrecoverableAudioError as e:
+            logger.error(f"App: Unrecoverable audio state: {e} — self-restart")
+            self._notify_error("音声ストリームが復旧不能のため再起動します")
+            schedule_self_restart(f"reinit: {e}")
         except (RuntimeError, sd.PortAudioError) as e:
             logger.exception(f"App: Failed to reinitialize audio stream: {e}")
             self._event_queue.put(f"error:Audio reinit failed: {e}")
@@ -379,6 +415,10 @@ class VoiceInputApp(rumps.App):
             self.recorder.reinitialize()
             self._event_queue.put("status:Ready")
             logger.info("App: Audio stream ready after wake")
+        except UnrecoverableAudioError as e:
+            logger.error(f"App: Unrecoverable audio state after wake: {e} — self-restart")
+            self._notify_error("復帰後に音声ストリーム復旧不能、再起動します")
+            schedule_self_restart(f"wake reinit: {e}")
         except Exception as e:
             logger.exception(f"App: Failed to reinitialize after wake: {e}")
             self._event_queue.put(f"error:Wake reinit failed: {e}")
@@ -416,6 +456,10 @@ class VoiceInputApp(rumps.App):
                 if self.recorder.is_initialized:
                     try:
                         self.recorder.reinitialize()
+                    except UnrecoverableAudioError as e:
+                        logger.error(f"App: Unrecoverable audio state on disconnect: {e}")
+                        schedule_self_restart(f"disconnect reinit: {e}")
+                        return
                     except Exception as e:
                         logger.warning(f"App: Reinitialize after disconnect failed: {e}")
                 if was_available:
@@ -428,6 +472,10 @@ class VoiceInputApp(rumps.App):
                 if self.recorder.is_initialized:
                     try:
                         self.recorder.reinitialize()
+                    except UnrecoverableAudioError as e:
+                        logger.error(f"App: Unrecoverable audio state on reconnect: {e}")
+                        schedule_self_restart(f"reconnect reinit: {e}")
+                        return
                     except Exception as e:
                         logger.warning(f"App: Reinitialize after reconnect failed: {e}")
                 if not was_available:

--- a/src/voice_input/app.py
+++ b/src/voice_input/app.py
@@ -252,19 +252,21 @@ class VoiceInputApp(rumps.App):
         """Poll for hotkey events from the queue."""
         # Detect a silently-stalled audio callback (e.g., AUHAL thread hung
         # without any sleep/device-change notification). If we believe we're
-        # recording but no sample has arrived for a while, abort and reinit.
+        # recording but no sample has arrived for a while, trigger recovery
+        # off the main (rumps) thread — the stream is already hung, so
+        # stop()/abort() here would block the UI for up to 1 second each.
         if self._is_recording and self.recorder.is_recording:
             idle = self.recorder.seconds_since_last_callback()
             if idle is not None and idle > CALLBACK_STALL_THRESHOLD_SEC:
                 logger.warning(
-                    "App: Audio callback stalled for %.1fs — forcing stop + reinit",
+                    "App: Audio callback stalled for %.1fs — offloading recovery",
                     idle,
                 )
+                # Flip flags eagerly so we don't re-enter this branch on the
+                # next 50ms tick while the worker is still running.
                 self._auto_stopped = True
                 self._is_recording = False
-                self._stop_recording()
-                self._event_queue.put("status:Ready (recovered from stall)")
-                self._event_queue.put("reinitialize")
+                self._event_queue.put("stall_recover")
                 return
 
         # Auto-stop for toggle mode if recording exceeds max duration
@@ -299,6 +301,10 @@ class VoiceInputApp(rumps.App):
                 elif event == "reinitialize":
                     threading.Thread(
                         target=self._reinitialize_audio, daemon=True
+                    ).start()
+                elif event == "stall_recover":
+                    threading.Thread(
+                        target=self._recover_from_stall, daemon=True
                     ).start()
                 elif event == "system_wake":
                     threading.Thread(
@@ -361,6 +367,30 @@ class VoiceInputApp(rumps.App):
             self._event_queue.put(f"error:Audio reinit failed: {e}")
         finally:
             self._reinit_lock.release()
+
+    def _recover_from_stall(self) -> None:
+        """Stop the hung stream and reinitialize, all off the main thread.
+
+        The main thread should never call ``recorder.stop()`` after a detected
+        stall: the AUHAL callback thread is stuck, so ``abort()`` will hit its
+        timeout and block the menu bar for a full second. Do both ``stop`` and
+        ``reinitialize`` here, and tell the user the in-flight recording is gone.
+        """
+        logger.info("App: Recovering from callback stall")
+        try:
+            # Drain the (empty) buffer and mark the recorder as stopped.
+            self.recorder.stop()
+        except sd.PortAudioError as e:
+            logger.warning(f"App: stop() during stall recovery raised: {e}")
+        # Tell the user their recording was lost — the "Processing..." UI
+        # they were about to see will not have any text to paste.
+        self.title = "Voice Input"
+        self.status_item.title = "Status: Ready (stall recovered)"
+        self._notify_error(
+            "マイクが応答しなくなったため録音を破棄しました。もう一度お試しください。"
+        )
+        # Hand reinitialize off to the existing worker so its lock is honored.
+        self._event_queue.put("reinitialize")
 
     # ------------------------------------------------------------------
     # Sleep / wake / device change handlers
@@ -547,6 +577,15 @@ class VoiceInputApp(rumps.App):
                 self.recorder.start()
                 logger.info("App: Recording started after reinitialize")
                 return
+            except UnrecoverableAudioError as reinit_err:
+                # PortAudio mutex is lost — any subsequent stream op would
+                # deadlock. Must bypass the generic RuntimeError handler below
+                # (UnrecoverableAudioError is a RuntimeError subclass).
+                logger.error(
+                    f"App: Unrecoverable audio state on start: {reinit_err} — self-restart"
+                )
+                self._notify_error("音声ストリームが復旧不能のため再起動します")
+                schedule_self_restart(f"start reinit: {reinit_err}")
             except (RuntimeError, sd.PortAudioError) as reinit_err:
                 logger.exception(
                     f"App: Failed to reinitialize/start recording: {reinit_err}"

--- a/src/voice_input/recorder.py
+++ b/src/voice_input/recorder.py
@@ -21,6 +21,15 @@ TERMINATE_TIMEOUT = 2.0  # Timeout for Pa_Terminate() in seconds
 logger = get_logger()
 
 
+class UnrecoverableAudioError(RuntimeError):
+    """Raised when PortAudio enters an unrecoverable state.
+
+    Typically this means Pa_Terminate() timed out, leaving the PortAudio
+    internal mutex held. Subsequent stream operations would deadlock, so the
+    only recovery is to restart the process.
+    """
+
+
 class StreamingRecorder:
     """Event-driven audio recorder using sounddevice InputStream.
 
@@ -33,6 +42,9 @@ class StreamingRecorder:
         self._stream: sd.InputStream | None = None
         self.is_recording: bool = False
         self._device: int | None = None
+        # Monotonic timestamp of the last audio callback while recording.
+        # Used by the app to detect a silently-stalled AUHAL callback thread.
+        self._last_callback_time: float | None = None
 
     def set_device(self, device: int | None) -> None:
         """Set the input device index (None = OS default)."""
@@ -63,16 +75,17 @@ class StreamingRecorder:
         self,
         indata: np.ndarray,
         frames: int,
-        time: object,
+        _time: object,
         status: sd.CallbackFlags,
     ) -> None:
         """Called by sounddevice for each audio chunk.
 
         Note:
-            frames, time, status are required by sounddevice's callback
+            frames, _time, status are required by sounddevice's callback
             signature but not used in this implementation.
             - frames: same as len(indata), redundant
-            - time: timestamp info, not needed for simple recording
+            - _time: timestamp info, not needed for simple recording
+              (renamed from ``time`` so it doesn't shadow the ``time`` module)
             - status: error flags (e.g. overflow), currently ignored
         """
         # Log audio stream status if there's an issue
@@ -80,6 +93,7 @@ class StreamingRecorder:
             logger.warning(f"Audio callback status: {status}")
 
         if self.is_recording:
+            self._last_callback_time = time.monotonic()
             self._queue.put_nowait(indata.copy())
 
     def initialize(self) -> None:
@@ -112,8 +126,18 @@ class StreamingRecorder:
                 break
 
         self.is_recording = True
+        # Seed the heartbeat so the stall detector waits for a real silence
+        # window from _now_, not from whenever the stream was last active.
+        self._last_callback_time = time.monotonic()
         self._stream.start()  # Resume stream (activates microphone)
         logger.info("Recording started")
+
+    def seconds_since_last_callback(self) -> float | None:
+        """Seconds since the last audio callback fired, or None if unknown."""
+        last = self._last_callback_time
+        if last is None:
+            return None
+        return time.monotonic() - last
 
     def _abort_with_timeout(self) -> bool:
         """Abort stream with timeout to prevent hanging.
@@ -228,8 +252,11 @@ class StreamingRecorder:
         t.start()
         t.join(timeout=TERMINATE_TIMEOUT)
         if t.is_alive():
-            logger.warning(
-                f"Pa_Terminate() timed out after {TERMINATE_TIMEOUT}s, forcing continue"
+            # PortAudio's internal mutex is still held by the abandoned thread.
+            # Any further Pa_Initialize / stream creation on this process will
+            # deadlock. Surface this so the app can self-restart.
+            raise UnrecoverableAudioError(
+                f"Pa_Terminate() timed out after {TERMINATE_TIMEOUT}s"
             )
 
         time.sleep(0.5)  # Allow macOS to fully release CoreAudio resources

--- a/src/voice_input/restart.py
+++ b/src/voice_input/restart.py
@@ -1,5 +1,6 @@
 """Self-restart helper for recovering from unrecoverable PortAudio state."""
 
+import logging
 import os
 import subprocess
 import sys
@@ -19,13 +20,20 @@ _MIN_RESTART_INTERVAL = 60.0
 
 
 def _throttled() -> bool:
-    """Return True if a recent restart happened within the throttle window."""
+    """Return True if a recent restart happened within the throttle window.
+
+    On any read failure we pessimistically return True (= suppress restart),
+    so a corrupted state file doesn't accidentally enable a crash loop.
+    """
     try:
         if not _THROTTLE_FILE.exists():
             return False
         last = float(_THROTTLE_FILE.read_text().strip())
-    except (OSError, ValueError):
-        return False
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            f"Restart: throttle file unreadable ({exc}); suppressing restart"
+        )
+        return True
     return (time.time() - last) < _MIN_RESTART_INTERVAL
 
 
@@ -35,6 +43,42 @@ def _record_restart() -> None:
         _THROTTLE_FILE.write_text(str(time.time()))
     except OSError as exc:
         logger.warning(f"Restart: failed to record throttle file: {exc}")
+
+
+def _resolve_bundle_path() -> Path | None:
+    """Return the enclosing ``.app`` bundle path, or None if unrecognisable.
+
+    Assumes the standard PyInstaller onedir + BUNDLE layout:
+    ``VoiceInput.app/Contents/MacOS/VoiceInput``.
+    """
+    exe = Path(sys.executable).resolve()
+    if len(exe.parents) < 3:
+        return None
+    candidate = exe.parents[2]
+    if candidate.suffix != ".app" or not candidate.exists():
+        return None
+    return candidate
+
+
+def _notify_user_sync(message: str) -> None:
+    """Block until a macOS notification has been dispatched.
+
+    ``rumps.notification`` queues through this process's run loop, which is
+    about to die; use ``osascript`` synchronously so the banner actually
+    surfaces before we exit.
+    """
+    try:
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'display notification "{message}" with title "Voice Input"',
+            ],
+            check=False,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning(f"Restart: notify failed: {exc}")
 
 
 def schedule_self_restart(reason: str) -> bool:
@@ -53,21 +97,23 @@ def schedule_self_restart(reason: str) -> bool:
 
     _record_restart()
     logger.warning(f"Restart: self-restart initiated. Reason: {reason}")
+    _notify_user_sync("音声ストリームを復旧できなかったため再起動します")
 
-    if getattr(sys, "frozen", False):
-        # PyInstaller bundle: executable lives at
-        # VoiceInput.app/Contents/MacOS/VoiceInput — walk up to the .app.
-        exe = Path(sys.executable).resolve()
-        bundle = exe.parents[2] if len(exe.parents) >= 3 else exe
+    bundle = _resolve_bundle_path() if getattr(sys, "frozen", False) else None
+    if bundle is not None:
         try:
             subprocess.Popen(["open", "-n", str(bundle)])
         except OSError as exc:
             logger.exception(f"Restart: failed to launch bundle: {exc}")
             return False
-        # Exit this process so the fresh instance can take over.
+        # Flush handlers before hard-exit — os._exit skips atexit/shutdown.
+        logging.shutdown()
         os._exit(0)
 
-    # Dev mode: replace this process in-place.
+    # Dev mode (or frozen build without a recognisable .app bundle): replace
+    # this process in place. ``os.execv`` also bypasses atexit, but the
+    # replacement image re-initialises logging on start.
+    logging.shutdown()
     try:
         os.execv(sys.executable, [sys.executable, *sys.argv])
     except OSError as exc:

--- a/src/voice_input/restart.py
+++ b/src/voice_input/restart.py
@@ -1,0 +1,76 @@
+"""Self-restart helper for recovering from unrecoverable PortAudio state."""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from .logger import get_logger
+
+logger = get_logger()
+
+# Throttle file: prevents restart loops by recording the last restart timestamp.
+_THROTTLE_FILE = Path.home() / ".voice-input" / ".last_restart"
+
+# Minimum seconds between self-restarts. A crash loop is more visible than
+# helpful, so refuse to restart if we already restarted this recently.
+_MIN_RESTART_INTERVAL = 60.0
+
+
+def _throttled() -> bool:
+    """Return True if a recent restart happened within the throttle window."""
+    try:
+        if not _THROTTLE_FILE.exists():
+            return False
+        last = float(_THROTTLE_FILE.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return (time.time() - last) < _MIN_RESTART_INTERVAL
+
+
+def _record_restart() -> None:
+    try:
+        _THROTTLE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _THROTTLE_FILE.write_text(str(time.time()))
+    except OSError as exc:
+        logger.warning(f"Restart: failed to record throttle file: {exc}")
+
+
+def schedule_self_restart(reason: str) -> bool:
+    """Relaunch this process, then terminate.
+
+    Returns:
+        True if a restart was launched; False if throttled (caller should
+        continue without restarting).
+    """
+    if _throttled():
+        logger.warning(
+            f"Restart: suppressed (< {_MIN_RESTART_INTERVAL}s since last restart). "
+            f"Reason: {reason}"
+        )
+        return False
+
+    _record_restart()
+    logger.warning(f"Restart: self-restart initiated. Reason: {reason}")
+
+    if getattr(sys, "frozen", False):
+        # PyInstaller bundle: executable lives at
+        # VoiceInput.app/Contents/MacOS/VoiceInput — walk up to the .app.
+        exe = Path(sys.executable).resolve()
+        bundle = exe.parents[2] if len(exe.parents) >= 3 else exe
+        try:
+            subprocess.Popen(["open", "-n", str(bundle)])
+        except OSError as exc:
+            logger.exception(f"Restart: failed to launch bundle: {exc}")
+            return False
+        # Exit this process so the fresh instance can take over.
+        os._exit(0)
+
+    # Dev mode: replace this process in-place.
+    try:
+        os.execv(sys.executable, [sys.executable, *sys.argv])
+    except OSError as exc:
+        logger.exception(f"Restart: execv failed: {exc}")
+        return False
+    return True  # unreachable

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -4,8 +4,10 @@ import time
 
 import sounddevice as sd
 
+import pytest
+
 import voice_input.recorder as recorder_module
-from voice_input.recorder import StreamingRecorder
+from voice_input.recorder import StreamingRecorder, UnrecoverableAudioError
 
 
 class DummyStream:
@@ -155,3 +157,41 @@ def test_stop_falls_back_to_abort_when_stream_stop_times_out(monkeypatch):
     assert called["abort"] == 1
     assert elapsed < 0.2
     assert audio.size == 0
+
+
+def test_reinitialize_raises_unrecoverable_when_pa_terminate_times_out(monkeypatch):
+    """Pa_Terminate timeout leaves PortAudio's mutex held. Any subsequent
+    stream operation would deadlock, so surface UnrecoverableAudioError so
+    the app can restart the process instead of hanging."""
+
+    def hanging_terminate():
+        while True:
+            time.sleep(0.1)
+
+    monkeypatch.setattr(recorder_module, "ABORT_TIMEOUT", 0.01)
+    monkeypatch.setattr(recorder_module, "TERMINATE_TIMEOUT", 0.05)
+    monkeypatch.setattr(sd, "_terminate", hanging_terminate)
+
+    recorder = StreamingRecorder()
+    recorder._stream = HangingAbortStream()
+
+    with pytest.raises(UnrecoverableAudioError):
+        recorder.reinitialize()
+
+
+def test_seconds_since_last_callback_none_before_start():
+    recorder = StreamingRecorder()
+    assert recorder.seconds_since_last_callback() is None
+
+
+def test_seconds_since_last_callback_tracks_callback(monkeypatch):
+    recorder = StreamingRecorder()
+    recorder.is_recording = True
+
+    # Simulate a callback firing
+    import numpy as np
+    recorder._audio_callback(np.zeros((10, 1), dtype=np.int16), 10, None, 0)
+
+    idle = recorder.seconds_since_last_callback()
+    assert idle is not None
+    assert idle < 1.0

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,163 @@
+"""Tests for the self-restart helper."""
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import voice_input.restart as restart
+
+
+@pytest.fixture
+def throttle_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the throttle file to a tmp path for the duration of the test."""
+    path = tmp_path / ".voice-input" / ".last_restart"
+    monkeypatch.setattr(restart, "_THROTTLE_FILE", path)
+    return path
+
+
+@pytest.fixture
+def patched_exits(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Intercept process-terminating calls so tests can assert them safely."""
+    calls: dict = {"popen": None, "execv": None, "exit": None, "notify": None}
+
+    def fake_popen(args):
+        calls["popen"] = args
+        return MagicMock()
+
+    def fake_execv(path, argv):
+        calls["execv"] = (path, argv)
+
+    def fake_exit(code):
+        calls["exit"] = code
+        # os._exit never returns; mimic that so callers don't continue into
+        # the execv fallback (which would otherwise record a spurious call).
+        raise SystemExit(code)
+
+    def fake_notify(message):
+        calls["notify"] = message
+
+    monkeypatch.setattr(restart.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(restart.os, "execv", fake_execv)
+    monkeypatch.setattr(restart.os, "_exit", fake_exit)
+    monkeypatch.setattr(restart, "_notify_user_sync", fake_notify)
+    return calls
+
+
+def test_throttled_returns_false_when_file_missing(throttle_file: Path) -> None:
+    assert not throttle_file.exists()
+    assert restart._throttled() is False
+
+
+def test_throttled_true_inside_window(throttle_file: Path) -> None:
+    throttle_file.parent.mkdir(parents=True, exist_ok=True)
+    throttle_file.write_text(str(time.time() - 5))  # 5s ago
+    assert restart._throttled() is True
+
+
+def test_throttled_false_outside_window(throttle_file: Path) -> None:
+    throttle_file.parent.mkdir(parents=True, exist_ok=True)
+    throttle_file.write_text(str(time.time() - (restart._MIN_RESTART_INTERVAL + 10)))
+    assert restart._throttled() is False
+
+
+def test_throttled_suppresses_on_corrupted_file(throttle_file: Path) -> None:
+    """Unreadable state should pessimistically block the restart."""
+    throttle_file.parent.mkdir(parents=True, exist_ok=True)
+    throttle_file.write_text("not-a-float")
+    assert restart._throttled() is True
+
+
+def test_schedule_self_restart_aborts_when_throttled(
+    throttle_file: Path,
+    patched_exits: dict,
+) -> None:
+    throttle_file.parent.mkdir(parents=True, exist_ok=True)
+    throttle_file.write_text(str(time.time()))  # now
+
+    assert restart.schedule_self_restart("test") is False
+    assert patched_exits["popen"] is None
+    assert patched_exits["execv"] is None
+    assert patched_exits["exit"] is None
+
+
+def test_schedule_self_restart_dev_mode_uses_execv(
+    throttle_file: Path,
+    patched_exits: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without sys.frozen and .app we fall through to os.execv."""
+    monkeypatch.delattr(sys, "frozen", raising=False)
+
+    restart.schedule_self_restart("dev reason")
+
+    assert patched_exits["execv"] is not None
+    path, argv = patched_exits["execv"]
+    assert path == sys.executable
+    assert argv[0] == sys.executable
+    # Did not try the bundle path.
+    assert patched_exits["popen"] is None
+    # Did not call os._exit in dev mode (execv replaces the process).
+    assert patched_exits["exit"] is None
+
+
+def test_schedule_self_restart_bundle_mode_uses_open(
+    throttle_file: Path,
+    patched_exits: dict,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside a .app bundle we invoke `open -n <bundle>` and os._exit(0)."""
+    bundle = tmp_path / "VoiceInput.app"
+    bundle_exe = bundle / "Contents" / "MacOS" / "VoiceInput"
+    bundle_exe.parent.mkdir(parents=True)
+    bundle_exe.touch()
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(bundle_exe))
+
+    with pytest.raises(SystemExit):
+        restart.schedule_self_restart("frozen reason")
+
+    assert patched_exits["popen"] is not None
+    assert patched_exits["popen"][0] == "open"
+    assert patched_exits["popen"][1] == "-n"
+    assert patched_exits["popen"][2] == str(bundle)
+    assert patched_exits["exit"] == 0
+    # Dev-mode execv must NOT run when we took the bundle path.
+    assert patched_exits["execv"] is None
+
+
+def test_schedule_self_restart_falls_back_when_bundle_not_app(
+    throttle_file: Path,
+    patched_exits: dict,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A frozen build whose parent isn't `.app` (onefile etc.) falls back to execv."""
+    exe = tmp_path / "random" / "bin" / "VoiceInput"
+    exe.parent.mkdir(parents=True)
+    exe.touch()
+
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(exe))
+
+    restart.schedule_self_restart("onefile reason")
+
+    # Bundle path not taken.
+    assert patched_exits["popen"] is None
+    assert patched_exits["exit"] is None
+    # execv path taken instead.
+    assert patched_exits["execv"] is not None
+
+
+def test_schedule_self_restart_emits_user_notification(
+    throttle_file: Path,
+    patched_exits: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    restart.schedule_self_restart("notify")
+    assert patched_exits["notify"] is not None


### PR DESCRIPTION
## 概要
sleep/wake 通知が届かないケースで実運用で観測された 2 種類のハングを自動復旧する：

1. **Silent callback stall**: AUHAL コールバックがサンプル配信を無言で停止。アプリは録音中と思い込んだままバッファ空の状態が続く。`seconds_since_last_callback()` を追跡し、録音中に 2 秒以上コールバックが来なかったら強制 stop + reinitialize する。

2. **Unrecoverable PortAudio state**: `Pa_Terminate()` をデーモンスレッドでタイムアウトさせると PortAudio の内部 mutex が握られたまま放棄され、以降の `sd._initialize()` / `sd.InputStream()` がメインスレッドでデッドロックする（「Initializing audio stream...」で UI ごとフリーズ）。`UnrecoverableAudioError` を raise して `schedule_self_restart()` を起動する。PyInstaller bundle は `open -n`、dev mode は `os.execv()`。60 秒スロットルで crash loop を抑止。

## レビュー反映
### Blocker
- `_start_recording` 内の再試行パスが `(RuntimeError, sd.PortAudioError)` のみ catch しており、`UnrecoverableAudioError` (RuntimeError サブクラス) が吸い込まれて自己再起動経路に乗っていなかった。先に catch するよう修正。
- stall 検出時に `_stop_recording()` を同期呼びしていたが、AUHAL が詰まっているので `abort()` が 1 秒タイムアウトして rumps のメインスレッドをブロック。`stall_recover` イベント経由で worker thread にオフロード。

### High
- 復旧時にユーザーへの通知が弱かったので「マイクが応答しなくなったため録音を破棄しました」の明示通知を追加。
- bundle 検出で `parents[2]` を問答無用で使っていたが、`.app` suffix を確認して不一致なら `os.execv` にフォールバック（onefile/dev frozen ビルド対応）。
- 自己再起動前に osascript の `display notification` を同期呼びして通知を確実に表示（`rumps.notification` は run loop ごと死ぬと配信されない）。
- `os._exit` / `os.execv` 前に `logging.shutdown()` を明示（自己再起動の warning がログに届くように）。
- `_throttled()` の例外時フォールバックを True に倒し、壊れた state file で無制限 crash loop に入らないようにした。

### テスト
- `tests/test_restart.py` を新規追加：スロットル境界、dev/bundle/onefile 分岐、ユーザー通知の副作用をカバー。

## ファイル
- `src/voice_input/recorder.py` — コールバックタイムスタンプ + `UnrecoverableAudioError`
- `src/voice_input/restart.py`（新規）— スロットル付き自己再起動ヘルパー
- `src/voice_input/app.py` — stall 検出、`UnrecoverableAudioError` catch（5 箇所）、stall recovery ハンドラ
- `tests/test_recorder.py` — +3 tests
- `tests/test_restart.py`（新規）— +9 tests

## テスト方針
- [x] `uv run pytest tests/` (全件 pass)
- [ ] マイクを録音中に切断 → 自動復旧ログを確認
- [ ] Pa_Terminate を強制タイムアウトさせて bundle が再起動されることを確認

## 依存
#21 (accessibility fix) を先に merge しないと、自己再起動後の bundle が segfault する

🤖 Generated with [Claude Code](https://claude.com/claude-code)