### PR TITLE
RMS しきい値と出力モードのメニューを追加（Paste + Auto-Submit）

### DIFF
--- a/src/voice_input/app.py
+++ b/src/voice_input/app.py
@@ -51,10 +51,12 @@ MODE_NAMES = {
     "toggle": "Toggle (押すたびに切替)",
 }
 
-# Output mode labels for menu display
+# Output mode labels for menu display. The ``paste_enter`` label leads with
+# the auto-submit warning so the user sees the destructive side-effect first;
+# clipboard preservation is the nicer secondary feature.
 OUTPUT_MODE_NAMES = {
     "copy_paste": "Copy & Paste",
-    "paste_enter": "Paste + Enter (preserve clipboard)",
+    "paste_enter": "Paste + Auto-Submit (keep clipboard)",
 }
 
 
@@ -73,7 +75,16 @@ class VoiceInputApp(rumps.App):
         self._config = load_config()
         self._current_hotkey = self._config.get("hotkey", "ctrl_l")
         self._current_mode = self._config.get("mode", "hold")
-        self._rms_threshold = self._config.get("rms_threshold", MIN_RMS_THRESHOLD)
+        rms_raw = self._config.get("rms_threshold", MIN_RMS_THRESHOLD)
+        if not isinstance(rms_raw, (int, float)) or rms_raw < 0:
+            # Defensive: a hand-edited config.json with a negative value would
+            # make the threshold check pass for every buffer (silence included)
+            # and a string would crash at comparison time. Fall back visibly.
+            logger.warning(
+                f"App: invalid rms_threshold {rms_raw!r} in config; using default"
+            )
+            rms_raw = MIN_RMS_THRESHOLD
+        self._rms_threshold = rms_raw
         self._current_input_device_name = self._config.get("input_device")
         self._max_recording_seconds = self._config.get("max_recording_seconds", 30.0)
         self._output_mode = self._config.get("output_mode", "copy_paste")
@@ -151,8 +162,22 @@ class VoiceInputApp(rumps.App):
         self._input_device_menu_populated = self._populate_input_device_menu()
 
     def _build_rms_menu(self) -> None:
-        """Populate the RMS threshold submenu with preset values."""
+        """Populate the RMS threshold submenu with preset values.
+
+        If the configured threshold is not one of the presets (e.g. the user
+        hand-edited config.json to 75), surface it as a non-clickable
+        ``Current: <value>`` row so they can still see what's active before
+        picking a preset to overwrite it.
+        """
         self._rms_items = {}
+
+        if self._rms_threshold not in VALID_RMS_THRESHOLDS:
+            current = rumps.MenuItem(f"Current: {self._rms_threshold}")
+            current.state = 1
+            # No callback = unclickable; the user changes this by picking a preset below.
+            self.rms_menu.add(current)
+            self.rms_menu.add(None)  # separator
+
         for value in VALID_RMS_THRESHOLDS:
             label = f"{value}" + (" (default)" if value == 100 else "")
             item = rumps.MenuItem(label, callback=self._on_rms_threshold_selected)

--- a/src/voice_input/app.py
+++ b/src/voice_input/app.py
@@ -11,7 +11,12 @@ import rumps
 import sounddevice as sd
 
 from .accessibility import check_accessibility_permission
-from .config import load_config, save_config
+from .config import (
+    VALID_OUTPUT_MODES,
+    VALID_RMS_THRESHOLDS,
+    load_config,
+    save_config,
+)
 from .device_monitor import DeviceMonitor
 from .hotkey import HOTKEY_NAMES, HotkeyListener
 from .logger import get_logger
@@ -46,6 +51,12 @@ MODE_NAMES = {
     "toggle": "Toggle (押すたびに切替)",
 }
 
+# Output mode labels for menu display
+OUTPUT_MODE_NAMES = {
+    "copy_paste": "Copy & Paste",
+    "paste_enter": "Paste + Enter (preserve clipboard)",
+}
+
 
 class VoiceInputApp(rumps.App):
     """Mac menu bar application for voice input using Whisper API."""
@@ -65,6 +76,9 @@ class VoiceInputApp(rumps.App):
         self._rms_threshold = self._config.get("rms_threshold", MIN_RMS_THRESHOLD)
         self._current_input_device_name = self._config.get("input_device")
         self._max_recording_seconds = self._config.get("max_recording_seconds", 30.0)
+        self._output_mode = self._config.get("output_mode", "copy_paste")
+        if self._output_mode not in VALID_OUTPUT_MODES:
+            self._output_mode = "copy_paste"
 
         # Toggle mode state
         self._is_recording = False
@@ -114,15 +128,73 @@ class VoiceInputApp(rumps.App):
         self._input_device_items = {}
         self._input_device_menu_populated = False
 
+        # RMS Threshold submenu (preset values only)
+        self.rms_menu = rumps.MenuItem("RMS Threshold")
+        self._rms_items: dict[int, rumps.MenuItem] = {}
+        self._build_rms_menu()
+
+        # Output submenu (copy_paste vs paste_enter)
+        self.output_menu = rumps.MenuItem("Output")
+        self._output_items: dict[str, rumps.MenuItem] = {}
+        self._build_output_menu()
+
         self.menu = [
             self.status_item,
             None,  # Separator
             self.hotkey_menu,
             self.mode_menu,
             self.input_device_menu,
+            self.rms_menu,
+            self.output_menu,
             rumps.MenuItem("Language: Japanese"),
         ]
         self._input_device_menu_populated = self._populate_input_device_menu()
+
+    def _build_rms_menu(self) -> None:
+        """Populate the RMS threshold submenu with preset values."""
+        self._rms_items = {}
+        for value in VALID_RMS_THRESHOLDS:
+            label = f"{value}" + (" (default)" if value == 100 else "")
+            item = rumps.MenuItem(label, callback=self._on_rms_threshold_selected)
+            item.rms_value = value
+            if value == self._rms_threshold:
+                item.state = 1
+            self._rms_items[value] = item
+            self.rms_menu.add(item)
+
+    def _on_rms_threshold_selected(self, sender: rumps.MenuItem) -> None:
+        """Handle RMS threshold preset selection."""
+        value = sender.rms_value
+        for item in self._rms_items.values():
+            item.state = 0
+        sender.state = 1
+        self._rms_threshold = value
+        self._config["rms_threshold"] = value
+        save_config(self._config)
+        logger.info(f"App: RMS threshold changed to {value}")
+
+    def _build_output_menu(self) -> None:
+        """Populate the Output submenu with available output modes."""
+        self._output_items = {}
+        for mode_id in VALID_OUTPUT_MODES:
+            label = OUTPUT_MODE_NAMES.get(mode_id, mode_id)
+            item = rumps.MenuItem(label, callback=self._on_output_mode_selected)
+            item.output_mode_id = mode_id
+            if mode_id == self._output_mode:
+                item.state = 1
+            self._output_items[mode_id] = item
+            self.output_menu.add(item)
+
+    def _on_output_mode_selected(self, sender: rumps.MenuItem) -> None:
+        """Handle output mode selection."""
+        mode_id = sender.output_mode_id
+        for item in self._output_items.values():
+            item.state = 0
+        sender.state = 1
+        self._output_mode = mode_id
+        self._config["output_mode"] = mode_id
+        save_config(self._config)
+        logger.info(f"App: Output mode changed to {mode_id}")
 
     def _on_hotkey_selected(self, sender: rumps.MenuItem) -> None:
         """Handle hotkey selection from menu."""
@@ -655,8 +727,8 @@ class VoiceInputApp(rumps.App):
             logger.info(f"App: Transcription complete ({len(text)} chars)")
 
             if text and text.strip():
-                logger.debug("App: Outputting text")
-                output_text(text)
+                logger.debug(f"App: Outputting text (mode={self._output_mode})")
+                output_text(text, mode=self._output_mode)
                 self._event_queue.put("status:Ready")
                 logger.info("App: Processing complete")
             else:

--- a/src/voice_input/config.py
+++ b/src/voice_input/config.py
@@ -11,9 +11,12 @@ DEFAULT_CONFIG = {
     "rms_threshold": 100,
     "input_device": None,
     "max_recording_seconds": 120.0,
+    "output_mode": "copy_paste",
 }
 
 VALID_HOTKEYS = ["ctrl_l", "ctrl_r", "alt_l", "alt_r"]
+VALID_OUTPUT_MODES = ["copy_paste", "paste_enter"]
+VALID_RMS_THRESHOLDS = [30, 50, 100, 200]
 
 
 def load_config() -> dict:

--- a/src/voice_input/output.py
+++ b/src/voice_input/output.py
@@ -61,11 +61,62 @@ def paste() -> None:
         logger.exception(f"Failed to paste: {e}")
 
 
-def output_text(text: str) -> None:
-    """Copy text to clipboard and paste it.
+# Delay after Cmd+V before restoring clipboard. macOS needs time to actually
+# read the clipboard via the paste event; restore too early and the paste
+# sees the restored (wrong) content.
+CLIPBOARD_RESTORE_DELAY = 0.2
+
+
+def press_enter() -> None:
+    """Simulate the Return key via AppleScript.
+
+    Uses AppleScript for the same reason as paste(): pynput/pyautogui
+    interfere when the hotkey listener is active.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "osascript",
+                "-e",
+                'tell application "System Events" to keystroke return',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=PASTE_TIMEOUT,
+        )
+        if result.returncode != 0:
+            logger.warning(f"osascript (enter) failed: {result.stderr}")
+        else:
+            logger.debug("Return sent via AppleScript")
+    except subprocess.TimeoutExpired:
+        logger.warning(f"osascript (enter) timed out after {PASTE_TIMEOUT}s")
+    except Exception as e:  # noqa: BLE001 - defensive, osascript is external
+        logger.exception(f"Failed to press Enter: {e}")
+
+
+def output_text(text: str, *, mode: str = "copy_paste") -> None:
+    """Deliver transcribed text to the active application.
 
     Args:
         text: Text to output.
+        mode: ``copy_paste`` (default) keeps text on the clipboard after pasting.
+            ``paste_enter`` preserves the user's pre-existing clipboard content
+            by restoring it after the paste, and presses Enter afterwards.
     """
+    if mode == "paste_enter":
+        original = pyperclip.paste()
+        copy_to_clipboard(text)
+        paste()
+        # Wait for the paste target to consume the clipboard before restoring.
+        time.sleep(CLIPBOARD_RESTORE_DELAY)
+        try:
+            pyperclip.copy(original)
+            logger.debug("Clipboard restored to pre-transcription content")
+        except Exception as e:  # noqa: BLE001 - pyperclip errors are opaque
+            logger.warning(f"Failed to restore clipboard: {e}")
+        press_enter()
+        return
+
+    # Default: copy_paste
     copy_to_clipboard(text)
     paste()

--- a/src/voice_input/output.py
+++ b/src/voice_input/output.py
@@ -94,27 +94,80 @@ def press_enter() -> None:
         logger.exception(f"Failed to press Enter: {e}")
 
 
+def _clipboard_has_non_text_payload() -> bool:
+    """Return True if the system clipboard holds image/file/RTF-only content.
+
+    pyperclip can only round-trip plain text, so if the user's current
+    clipboard is an image or a file reference the save/restore trick in
+    ``paste_enter`` mode would silently erase it. Detect that case so we can
+    skip the restore step and leave the data lost-but-acknowledged rather
+    than silently.
+
+    Only available on macOS with pyobjc (AppKit). On other platforms this
+    returns False and the caller falls back to the plain-text path.
+    """
+    try:
+        from AppKit import NSPasteboard
+    except ImportError:
+        return False
+    pb = NSPasteboard.generalPasteboard()
+    types = list(pb.types() or [])
+    if not types:
+        return False
+    # Text-bearing UTIs we can safely round-trip through pyperclip.
+    text_utis = {
+        "public.utf8-plain-text",
+        "public.plain-text",
+        "public.utf16-plain-text",
+        "NSStringPboardType",
+    }
+    return not any(t in text_utis for t in types)
+
+
 def output_text(text: str, *, mode: str = "copy_paste") -> None:
     """Deliver transcribed text to the active application.
 
     Args:
         text: Text to output.
-        mode: ``copy_paste`` (default) keeps text on the clipboard after pasting.
-            ``paste_enter`` preserves the user's pre-existing clipboard content
-            by restoring it after the paste, and presses Enter afterwards.
+        mode: ``copy_paste`` (default) keeps text on the clipboard after
+            pasting. ``paste_enter`` preserves the user's pre-existing
+            *text* clipboard content by restoring it after the paste, and
+            then presses Enter to auto-submit. If the clipboard holds
+            non-text data (image/file) the restore is skipped — pyperclip
+            would clobber it anyway — and a warning is logged.
     """
     if mode == "paste_enter":
-        original = pyperclip.paste()
-        copy_to_clipboard(text)
-        paste()
-        # Wait for the paste target to consume the clipboard before restoring.
-        time.sleep(CLIPBOARD_RESTORE_DELAY)
+        non_text = _clipboard_has_non_text_payload()
+        if non_text:
+            logger.warning(
+                "Clipboard holds non-text data; it will be lost by paste_enter"
+            )
+            original = None
+        else:
+            original = pyperclip.paste()
+
+        paste_ok = False
         try:
-            pyperclip.copy(original)
-            logger.debug("Clipboard restored to pre-transcription content")
-        except Exception as e:  # noqa: BLE001 - pyperclip errors are opaque
-            logger.warning(f"Failed to restore clipboard: {e}")
-        press_enter()
+            copy_to_clipboard(text)
+            paste()
+            # Wait for the paste target to consume the clipboard before restoring.
+            time.sleep(CLIPBOARD_RESTORE_DELAY)
+            paste_ok = True
+        finally:
+            # Restore in a finally block so an exception during paste still
+            # returns the user's clipboard. Only restore if we captured text
+            # (skipping for non-text clipboards avoids clobbering images).
+            if original is not None:
+                try:
+                    pyperclip.copy(original)
+                    logger.debug("Clipboard restored to pre-transcription content")
+                except Exception as e:  # noqa: BLE001 - pyperclip errors are opaque
+                    logger.warning(f"Failed to restore clipboard: {e}")
+        # Only auto-submit when the paste actually succeeded. A failed paste
+        # means the target app never got the text, so pressing Enter would
+        # submit whatever stale input is already in the field.
+        if paste_ok:
+            press_enter()
         return
 
     # Default: copy_paste

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,138 @@
+"""Tests for the output dispatcher (copy_paste vs paste_enter modes)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import voice_input.output as output
+
+
+@pytest.fixture
+def fake_clipboard(monkeypatch: pytest.MonkeyPatch):
+    """Replace pyperclip with an in-memory mock that tracks copy/paste order."""
+    state = {"current": "", "history": []}
+
+    def fake_copy(value: str) -> None:
+        state["current"] = value
+        state["history"].append(value)
+
+    def fake_paste() -> str:
+        return state["current"]
+
+    monkeypatch.setattr(output.pyperclip, "copy", fake_copy)
+    monkeypatch.setattr(output.pyperclip, "paste", fake_paste)
+    return state
+
+
+@pytest.fixture
+def stub_paste_and_enter(monkeypatch: pytest.MonkeyPatch):
+    """Replace paste() and press_enter() with fakes so we can count calls."""
+    calls = {"paste": 0, "enter": 0, "paste_error": None}
+
+    def fake_paste():
+        calls["paste"] += 1
+        err = calls["paste_error"]
+        if err is not None:
+            raise err
+
+    def fake_enter():
+        calls["enter"] += 1
+
+    monkeypatch.setattr(output, "paste", fake_paste)
+    monkeypatch.setattr(output, "press_enter", fake_enter)
+    # Avoid sleeping in tests.
+    monkeypatch.setattr(output.time, "sleep", lambda _s: None)
+    return calls
+
+
+@pytest.fixture
+def text_only_clipboard(monkeypatch: pytest.MonkeyPatch):
+    """Force _clipboard_has_non_text_payload() to False for the test."""
+    monkeypatch.setattr(output, "_clipboard_has_non_text_payload", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# copy_paste mode
+# ---------------------------------------------------------------------------
+
+
+def test_copy_paste_writes_text_and_pastes(
+    fake_clipboard,
+    stub_paste_and_enter,
+):
+    output.output_text("hello", mode="copy_paste")
+
+    assert fake_clipboard["current"] == "hello"
+    assert stub_paste_and_enter["paste"] == 1
+    # copy_paste must NOT press Enter.
+    assert stub_paste_and_enter["enter"] == 0
+
+
+def test_default_mode_is_copy_paste(fake_clipboard, stub_paste_and_enter):
+    output.output_text("hi")
+    assert fake_clipboard["current"] == "hi"
+    assert stub_paste_and_enter["enter"] == 0
+
+
+# ---------------------------------------------------------------------------
+# paste_enter mode
+# ---------------------------------------------------------------------------
+
+
+def test_paste_enter_restores_clipboard_and_submits(
+    fake_clipboard,
+    stub_paste_and_enter,
+    text_only_clipboard,
+):
+    # Seed the clipboard with something the user copied earlier.
+    fake_clipboard["current"] = "https://example.com"
+    fake_clipboard["history"].clear()
+
+    output.output_text("こんにちは", mode="paste_enter")
+
+    # After the dust settles, the user's URL must be back on the clipboard.
+    assert fake_clipboard["current"] == "https://example.com"
+    # The transcription must have been on the clipboard at some point.
+    assert "こんにちは" in fake_clipboard["history"]
+    # Paste and Enter both fire exactly once.
+    assert stub_paste_and_enter["paste"] == 1
+    assert stub_paste_and_enter["enter"] == 1
+
+
+def test_paste_enter_restores_even_when_paste_fails(
+    fake_clipboard,
+    stub_paste_and_enter,
+    text_only_clipboard,
+):
+    fake_clipboard["current"] = "original"
+    stub_paste_and_enter["paste_error"] = RuntimeError("paste kaput")
+
+    with pytest.raises(RuntimeError, match="paste kaput"):
+        output.output_text("new", mode="paste_enter")
+
+    # try/finally must still restore the original clipboard content.
+    assert fake_clipboard["current"] == "original"
+    # No auto-submit when paste failed — avoids sending garbage to the target.
+    assert stub_paste_and_enter["enter"] == 0
+
+
+def test_paste_enter_skips_restore_for_non_text_clipboard(
+    fake_clipboard,
+    stub_paste_and_enter,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-text clipboards (images/files) cannot be round-tripped via pyperclip."""
+    monkeypatch.setattr(output, "_clipboard_has_non_text_payload", lambda: True)
+    # Clipboard starts with "whatever pyperclip reads from an image" — here just
+    # an empty string as pyperclip would return for non-text content.
+    fake_clipboard["current"] = ""
+
+    output.output_text("new", mode="paste_enter")
+
+    # We must NOT clobber the clipboard back to the (empty) text we read —
+    # leaving the app's own "new" string there is marginally better than
+    # erasing the user's image to an empty string, and the warning told them.
+    # Final state is the transcription we just wrote.
+    assert fake_clipboard["current"] == "new"
+    # Still auto-submit: paste succeeded, that's what the user asked for.
+    assert stub_paste_and_enter["enter"] == 1


### PR DESCRIPTION
## 概要
これまで `~/.voice-input/config.json` の手編集でしか変えられなかった 2 つの設定をメニューバーから操作できるようにする：

- **RMS Threshold** submenu: 30 / 50 / 100 (default) / 200。マイク入力音量のばらつきに JSON 編集なしで対応できる。
- **Output** submenu: 現状の `Copy & Paste` と、新しい `Paste + Auto-Submit (keep clipboard)` の切替。

## Paste + Auto-Submit の挙動
1. 既存のクリップボード内容を保存
2. 文字起こしをクリップボードに書き込み → `Cmd+V` 送信
3. ターゲットが paste を消費する猶予として 200ms 待機
4. 元のクリップボード内容を書き戻し
5. AppleScript で Return を送信して自動送信

## 動機
典型的な flow「URL をコピー → 喋って音声入力 → URL を別の場所にペースト」で、現状は URL がクリップボードから消える。新モードは URL を保ったまま、チャット UI に「喋る → 送信」を 1 アクションでこなせる。

## レビュー反映
### High
- `try/finally` で例外安全化：paste 中に例外が出てもユーザーのクリップボードを必ず復元する。`press_enter()` を finally の外に出して、paste 失敗時は自動送信しない（ターゲットに残った古い入力を誤送信するリスクを排除）。
- 非テキストクリップボード（画像 / RTF / ファイル）を `NSPasteboard` で検出：pyperclip では画像を空文字で round-trip してしまい復元時に破壊する。検出時は復元をスキップして warning。非 macOS では False を返して従来パスにフォールバック。
- メニューラベルを `Paste + Enter (preserve clipboard)` → `Paste + Auto-Submit (keep clipboard)` に変更し、自動送信のリスクを前面に表示。クリップボード保持は副次効果として括弧内に。

### Medium
- config ロード時に `rms_threshold` を validation：手編集で負値や文字列が入ったら default にフォールバックして warning（負値は常時録音扱い、文字列は比較時クラッシュ）。
- プリセット外の rms_threshold を `Current: <value>` の非クリック行として presets の上に表示（ユーザーが手編集した値を見える化）。
- `tests/test_output.py` を新規追加：copy_paste / paste_enter 正常系 / paste 失敗時の復元 + Enter 抑止 / 非テキストクリップボード、を検証。

## ファイル
- `src/voice_input/config.py` — `output_mode` / `VALID_OUTPUT_MODES` / `VALID_RMS_THRESHOLDS` を追加
- `src/voice_input/output.py` — `press_enter()`、`_clipboard_has_non_text_payload()`、`output_text` に `mode` パラメータ
- `src/voice_input/app.py` — 2 つの新 submenu + ハンドラ + dispatch、rms validation、Current 表示
- `tests/test_output.py`（新規）— +5 tests

## テスト方針
- [x] `uv run pytest tests/` (全件 pass)
- [ ] URL をコピー → `paste_enter` で発話 → クリップボードが URL に戻ることを確認
- [ ] Slack で発話 → Return で送信されることを確認
- [ ] config.json を手編集して `rms_threshold: 75` → メニュー上部に `Current: 75` が出ることを確認

## 依存
#21 (accessibility fix) と #22 (audio hang recovery) を先に merge してから production bundle に適用するのがおすすめ

🤖 Generated with [Claude Code](https://claude.com/claude-code)